### PR TITLE
adding in getdents fix from master before discard

### DIFF
--- a/seattlelib/fs_getdents.repy
+++ b/seattlelib/fs_getdents.repy
@@ -2,12 +2,12 @@
 
 Handlers for the getdents system call.
 
-Called from dispatcher.Repy
+Called from dispatcher.repy
 
 Safe version checks all parameters, then calls real handler.
 
 Getdents handler pulls out the arguments, does any mandatory checking
-then calls the Repy POSIX library getdents system call.  Then packs
+then calls the repy SafePOSIX library getdents system call.  Then packs
 the result back up.
 
 """
@@ -15,11 +15,11 @@ the result back up.
 
 def pack_dirent(dir_tuple, my_start):
     """
-    Given the Pyhton tuple produced by the Repy POSIX library, build the
+    Given the python tuple produced by the repy SafePOSIX library, build the
     corresponding C struct.  This is tricky because it has offsets from
     the previous entries.
 
-    See man 2 getdnents for the struct format is wrong. See below
+    See man 2 getdents for the struct format is wrong. See below
     format obtained by testing
 
     dir_tuple is the tuple with the info (inode, name)
@@ -51,7 +51,7 @@ def pack_dirent(dir_tuple, my_start):
     formatwopadding = "<Q<q<H" + str(len(d_name)) + "s<B"
 
     nopaddirent_len = struct_calcsize(formatwopadding)
-    # This will double word align it...
+    # Calculate padding to double word align it...
     paddingsize = 8-(nopaddirent_len % 8)
      
     # Now actually build the format string...
@@ -59,7 +59,7 @@ def pack_dirent(dir_tuple, my_start):
     actual_dirent_len = struct_calcsize(format)
     d_off = my_start + actual_dirent_len
         
-    # and then pack things in...
+    # and then pack things in adding NULL's to fill the padding
     dirent = struct_pack(format, d_ino, d_off, actual_dirent_len, d_name, "\0"*paddingsize, d_type)
     
     return (d_off, dirent)
@@ -68,7 +68,7 @@ def pack_dirent(dir_tuple, my_start):
 def lind_fs_getdents(args):
     """ getdents calls are dispatched to this function.
 
-    See dispatcher.Repy for details.
+    See dispatcher.repy for details.
 
     Given the file handle and max_bytes, return
     up to the dirents that fit in that space.
@@ -105,7 +105,7 @@ def lind_fs_getdents(args):
 def lind_safe_fs_getdents(args):
     """ Safely wrap the getdents call.
 
-    See dispatcher. Repy for details.
+    See dispatcher.repy for details.
 
     Check the handle and count for consistency,
     then call the real getdents dispatcher.

--- a/seattlelib/fs_getdents.repy
+++ b/seattlelib/fs_getdents.repy
@@ -2,12 +2,12 @@
 
 Handlers for the getdents system call.
 
-Called from dispatcher.repy
+Called from dispatcher.Repy
 
 Safe version checks all parameters, then calls real handler.
 
 Getdents handler pulls out the arguments, does any mandatory checking
-then calls the repy posix library getdents system call.  Then packs
+then calls the Repy POSIX library getdents system call.  Then packs
 the result back up.
 
 """
@@ -15,8 +15,8 @@ the result back up.
 
 def pack_dirent(dir_tuple, my_start):
     """
-    Given the python tuple produced by the repy posix library, build the
-    corrosponding C struct.  This is tricky because it has offsets from
+    Given the Pyhton tuple produced by the Repy POSIX library, build the
+    corresponding C struct.  This is tricky because it has offsets from
     the previous entries.
 
     See man 2 getdnents for the struct format is wrong. See below
@@ -35,25 +35,40 @@ def pack_dirent(dir_tuple, my_start):
         d_type = dir_tuple[2]
     else:
         d_type = DT_UNKNOWN  # TODO: set this
-
+    
     # the format of the dirent struct is:
     #    unsigned long long d_ino
     #    signed long long offset
     #    unsigned short reclen
-    #    char type
     #    char[] d_name
+	#    char pad
+    #    char type
 
-    format = "<Q<q<H<B" + str(len(d_name)) + "s<B"
-    dirent_len = struct_calcsize(format)
-    d_off = my_start + dirent_len
-    dirent = struct_pack(format, d_ino, d_off, dirent_len, d_type, d_name, 0)
+    # We want to double word align this because C does so for the dirent structure.  This is meant to make any code that assumes this is true work
+    # better, even though we are justified in not doing so by the specification.
+
+    # compute the size w/o the padding byte first
+    formatwopadding = "<Q<q<H" + str(len(d_name)) + "s<B"
+
+    nopaddirent_len = struct_calcsize(formatwopadding)
+    # This will double word align it...
+    paddingsize = 8-(nopaddirent_len % 8)
+     
+    # Now actually build the format string...
+    format = "<Q<q<H" + str(len(d_name)) + "s"+str(paddingsize)+"s<B"
+    actual_dirent_len = struct_calcsize(format)
+    d_off = my_start + actual_dirent_len
+        
+    # and then pack things in...
+    dirent = struct_pack(format, d_ino, d_off, actual_dirent_len, d_name, "\0"*paddingsize, d_type)
+    
     return (d_off, dirent)
 
 
 def lind_fs_getdents(args):
     """ getdents calls are dispatched to this function.
 
-    See dispatcher.repy for details.
+    See dispatcher.Repy for details.
 
     Given the file handle and max_bytes, return
     up to the dirents that fit in that space.
@@ -65,11 +80,11 @@ def lind_fs_getdents(args):
 
     #max bytes
     count = args[1]
-
+	    
     try:
         py_result = get_fs_call(args[-1],"getdents_syscall")(handle, count)
+
     except SyscallError, e:
-        print "ERROR!", e
         return ErrorResponseBuilder("fs_getdents", e[1], e[2])
 
     if not py_result:
@@ -81,15 +96,16 @@ def lind_fs_getdents(args):
         (off_delta, str_ent) = pack_dirent(ent, offset_cur)
         offset_cur = off_delta
         final_structs.append(str_ent)
-
+	
     result = ''.join(final_structs)
+
     return SuccessResponseBuilder("fs_getdents", len(result), result)
 
 
 def lind_safe_fs_getdents(args):
     """ Safely wrap the getdents call.
 
-    See dispatcher.repy for details.
+    See dispatcher. Repy for details.
 
     Check the handle and count for consistency,
     then call the real getdents dispatcher.
@@ -100,9 +116,10 @@ def lind_safe_fs_getdents(args):
 
     check_valid_fd_handle(handle)
     assert isinstance(count, int)
-
+	
+	 
     result = lind_fs_getdents(args)
-
+	
     if result.is_error == False:
         #assert(len(result.data) <= TX_BUF_MAX), \
         #    "returning data larger than transmission buffer."

--- a/seattlelib/fs_getdents.repy
+++ b/seattlelib/fs_getdents.repy
@@ -35,13 +35,13 @@ def pack_dirent(dir_tuple, my_start):
         d_type = dir_tuple[2]
     else:
         d_type = DT_UNKNOWN  # TODO: set this
-    
-    # the format of the dirent struct is:
+
+# the format of the dirent struct is:
     #    unsigned long long d_ino
     #    signed long long offset
     #    unsigned short reclen
     #    char[] d_name
-	#    char pad
+    #    char pad
     #    char type
 
     # We want to double word align this because C does so for the dirent structure.  This is meant to make any code that assumes this is true work
@@ -53,15 +53,15 @@ def pack_dirent(dir_tuple, my_start):
     nopaddirent_len = struct_calcsize(formatwopadding)
     # Calculate padding to double word align it...
     paddingsize = 8-(nopaddirent_len % 8)
-     
+
     # Now actually build the format string...
     format = "<Q<q<H" + str(len(d_name)) + "s"+str(paddingsize)+"s<B"
     actual_dirent_len = struct_calcsize(format)
     d_off = my_start + actual_dirent_len
-        
+
     # and then pack things in adding NULL's to fill the padding
     dirent = struct_pack(format, d_ino, d_off, actual_dirent_len, d_name, "\0"*paddingsize, d_type)
-    
+
     return (d_off, dirent)
 
 
@@ -80,7 +80,7 @@ def lind_fs_getdents(args):
 
     #max bytes
     count = args[1]
-	    
+
     try:
         py_result = get_fs_call(args[-1],"getdents_syscall")(handle, count)
 
@@ -96,7 +96,7 @@ def lind_fs_getdents(args):
         (off_delta, str_ent) = pack_dirent(ent, offset_cur)
         offset_cur = off_delta
         final_structs.append(str_ent)
-	
+
     result = ''.join(final_structs)
 
     return SuccessResponseBuilder("fs_getdents", len(result), result)
@@ -116,10 +116,9 @@ def lind_safe_fs_getdents(args):
 
     check_valid_fd_handle(handle)
     assert isinstance(count, int)
-	
-	 
+
     result = lind_fs_getdents(args)
-	
+
     if result.is_error == False:
         #assert(len(result.data) <= TX_BUF_MAX), \
         #    "returning data larger than transmission buffer."
@@ -127,3 +126,4 @@ def lind_safe_fs_getdents(args):
         assert(len(result.data) <= count), \
                "not observing byte count parameter."
     return result
+


### PR DESCRIPTION
This fixes the formatting error that was causing rogue characters to show up in programs such as "ls".