### PR TITLE
Added syscall implementations for pread and pwrite and fixed a bug in open syscall

### DIFF
--- a/seattlelib/dispatcher.repy
+++ b/seattlelib/dispatcher.repy
@@ -72,7 +72,10 @@ def setup_dispatcher(comp_num):
     107:lind_comp_accept,
     108:lind_comp_recv,
     
-    125:lind_safe_net_gethostname
+    125:lind_safe_net_gethostname,
+    
+    126:lind_safe_fs_pread,
+    127:lind_safe_fs_pwrite
     }
     
   elif MODE == "fast":
@@ -141,8 +144,10 @@ def setup_dispatcher(comp_num):
     107:lind_comp_accept,
     108:lind_comp_recv,
     
-    125:lind_net_gethostname
-
+    125:lind_net_gethostname,
+    
+    126:lind_fs_pread,
+    127:lind_fs_pwrite
     }
   else:
     assert False, "Invalid mode setting"

--- a/seattlelib/fs_pread.repy
+++ b/seattlelib/fs_pread.repy
@@ -35,14 +35,11 @@ def lind_fs_pread(args):
     #if size > TX_BUF_MAX:
     #    size = TX_BUF_MAX
 
-    if IS_SOCK_DESC(handle,args[-1]):
-        return ErrorResponseBuilder("fs_pread","ESPIPE","File descriptor is associated with a pipe or FIFO or socket.")
+    try:
+        result = get_fs_call(args[-1],"pread_syscall")(handle, size, offset)
+    except SyscallError, e:
+        return ErrorResponseBuilder("fs_pread", e[1], e[2])
         
-    else:
-        try:
-            result = get_fs_call(args[-1],"pread_syscall")(handle, size, offset)
-        except SyscallError, e:
-            return ErrorResponseBuilder("fs_pread", e[1], e[2])
             
     return SuccessResponseBuilder("fs_pread", len(result), result)
 

--- a/seattlelib/fs_pread.repy
+++ b/seattlelib/fs_pread.repy
@@ -36,7 +36,7 @@ def lind_fs_pread(args):
     #    size = TX_BUF_MAX
 
     if IS_SOCK_DESC(handle,args[-1]):
-        return ErrorResponseBuilder("pread_syscall","ESPIPE","File descriptor is associated with a pipe or FIFO or socket.")
+        return ErrorResponseBuilder("fs_pread","ESPIPE","File descriptor is associated with a pipe or FIFO or socket.")
         
     else:
         try:

--- a/seattlelib/fs_pread.repy
+++ b/seattlelib/fs_pread.repy
@@ -1,0 +1,75 @@
+"""
+
+Handlers for the pread system call.
+
+Called from dispatcher.repy
+
+Safe version checks all parameters, then calls real handler.
+
+Read handler pulls out the arguments, does any mandatory checking
+then calls the repy posix library pread system call.  Then packs
+the result back up.
+
+"""
+
+
+def lind_fs_pread(args):
+    """ pread calls are dispatched to this function.
+
+    See dispatcher.repy for details.
+
+    Given the handle and size in a list,
+    pull them out and make the actual syscall in the
+    file system library.
+
+    Pack the single int returned, or error.
+    """
+
+    handle = args[0]
+    size = args[1]
+
+    # so really this should be fixed
+    # but right now big requests dont work!
+    # so truncate the request
+    #if size > TX_BUF_MAX:
+    #    size = TX_BUF_MAX
+
+    if IS_SOCK_DESC(handle,args[-1]):
+        try:
+            if size == 0:
+                size == TX_BUF_MAX
+            result = get_fs_call(args[-1],"recv_syscall")(handle, size, 0)
+        except SocketWouldBlockError as e:
+            return ErrorResponseBuilder("fs_read", "EAGAIN", "Socket would block")
+        except SyscallError, e:
+            return ErrorResponseBuilder("fs_read", e[1], e[2])
+    else:
+        try:
+            result = get_fs_call(args[-1],"read_syscall")(handle, size)
+        except SyscallError, e:
+            return ErrorResponseBuilder("fs_read", e[1], e[2])
+            
+    return SuccessResponseBuilder("fs_read", len(result), result)
+
+
+def lind_safe_fs_pread(args):
+    """ Safely wrap the pread call.
+
+    See dispatcher.repy for details.
+
+    Check the handle and size for consistency,
+    then call the real read dispatcher.
+
+    """
+
+    handle = args[0]
+    size = args[1]
+    check_valid_fd_handle(handle)
+    assert isinstance(size, int)
+
+    result = lind_fs_read(args)
+
+    #if result.is_error == False:
+    #    assert(len(result.data) <= TX_BUF_MAX), "returning data larger than transmission buffer."
+
+    return result

--- a/seattlelib/fs_pread.repy
+++ b/seattlelib/fs_pread.repy
@@ -14,11 +14,11 @@ the result back up.
 
 
 def lind_fs_pread(args):
-    """ pread calls are dispatched to this function. TODO: FIX AFTER IMPLEMENTATION
+    """ pread calls are dispatched to this function.
 
     See dispatcher.repy for details.
 
-    Given the handle and size in a list,
+    Given the handle, size, and offset in a list,
     pull them out and make the actual syscall in the
     file system library.
 
@@ -27,6 +27,7 @@ def lind_fs_pread(args):
 
     handle = args[0]
     size = args[1]
+    offset = args[2]
 
     # so really this should be fixed
     # but right now big requests dont work!
@@ -45,7 +46,7 @@ def lind_fs_pread(args):
             return ErrorResponseBuilder("fs_pread", e[1], e[2])
     else:
         try:
-            result = get_fs_call(args[-1],"pread_syscall")(handle, size)
+            result = get_fs_call(args[-1],"pread_syscall")(handle, size, offset)
         except SyscallError, e:
             return ErrorResponseBuilder("fs_pread", e[1], e[2])
             
@@ -64,9 +65,11 @@ def lind_safe_fs_pread(args):
 
     handle = args[0]
     size = args[1]
+    offset = args[2]
     check_valid_fd_handle(handle)
     assert isinstance(size, int)
-
+    assert isinstance(offset, int)
+    
     result = lind_fs_pread(args)
 
     #if result.is_error == False:

--- a/seattlelib/fs_pread.repy
+++ b/seattlelib/fs_pread.repy
@@ -14,7 +14,7 @@ the result back up.
 
 
 def lind_fs_pread(args):
-    """ pread calls are dispatched to this function.
+    """ pread calls are dispatched to this function. TODO: FIX AFTER IMPLEMENTATION
 
     See dispatcher.repy for details.
 
@@ -40,16 +40,16 @@ def lind_fs_pread(args):
                 size == TX_BUF_MAX
             result = get_fs_call(args[-1],"recv_syscall")(handle, size, 0)
         except SocketWouldBlockError as e:
-            return ErrorResponseBuilder("fs_read", "EAGAIN", "Socket would block")
+            return ErrorResponseBuilder("fs_pread", "EAGAIN", "Socket would block")
         except SyscallError, e:
-            return ErrorResponseBuilder("fs_read", e[1], e[2])
+            return ErrorResponseBuilder("fs_pread", e[1], e[2])
     else:
         try:
-            result = get_fs_call(args[-1],"read_syscall")(handle, size)
+            result = get_fs_call(args[-1],"pread_syscall")(handle, size)
         except SyscallError, e:
-            return ErrorResponseBuilder("fs_read", e[1], e[2])
+            return ErrorResponseBuilder("fs_pread", e[1], e[2])
             
-    return SuccessResponseBuilder("fs_read", len(result), result)
+    return SuccessResponseBuilder("fs_pread", len(result), result)
 
 
 def lind_safe_fs_pread(args):
@@ -67,7 +67,7 @@ def lind_safe_fs_pread(args):
     check_valid_fd_handle(handle)
     assert isinstance(size, int)
 
-    result = lind_fs_read(args)
+    result = lind_fs_pread(args)
 
     #if result.is_error == False:
     #    assert(len(result.data) <= TX_BUF_MAX), "returning data larger than transmission buffer."

--- a/seattlelib/fs_pread.repy
+++ b/seattlelib/fs_pread.repy
@@ -18,7 +18,7 @@ def lind_fs_pread(args):
 
     See dispatcher.repy for details.
 
-    Given the handle, size, and offset in a list,
+    Given the handle, size, and offset in a list;
     pull them out and make the actual syscall in the
     file system library.
 
@@ -58,7 +58,7 @@ def lind_safe_fs_pread(args):
 
     See dispatcher.repy for details.
 
-    Check the handle and size for consistency,
+    Check the handle, size, and offset for consistency;
     then call the real read dispatcher.
 
     """

--- a/seattlelib/fs_pread.repy
+++ b/seattlelib/fs_pread.repy
@@ -36,14 +36,8 @@ def lind_fs_pread(args):
     #    size = TX_BUF_MAX
 
     if IS_SOCK_DESC(handle,args[-1]):
-        try:
-            if size == 0:
-                size == TX_BUF_MAX
-            result = get_fs_call(args[-1],"recv_syscall")(handle, size, 0)
-        except SocketWouldBlockError as e:
-            return ErrorResponseBuilder("fs_pread", "EAGAIN", "Socket would block")
-        except SyscallError, e:
-            return ErrorResponseBuilder("fs_pread", e[1], e[2])
+        return ErrorResponseBuilder("pread_syscall","ESPIPE","File descriptor is associated with a pipe or FIFO or socket.")
+        
     else:
         try:
             result = get_fs_call(args[-1],"pread_syscall")(handle, size, offset)

--- a/seattlelib/fs_pread.repy
+++ b/seattlelib/fs_pread.repy
@@ -6,7 +6,7 @@ Called from dispatcher.repy
 
 Safe version checks all parameters, then calls real handler.
 
-Read handler pulls out the arguments, does any mandatory checking
+Pread handler pulls out the arguments, does any mandatory checking
 then calls the repy posix library pread system call.  Then packs
 the result back up.
 
@@ -59,7 +59,7 @@ def lind_safe_fs_pread(args):
     See dispatcher.repy for details.
 
     Check the handle, size, and offset for consistency;
-    then call the real read dispatcher.
+    then call the real pread dispatcher.
 
     """
 

--- a/seattlelib/fs_pwrite.repy
+++ b/seattlelib/fs_pwrite.repy
@@ -6,15 +6,16 @@ Called from dispatcher.repy
 
 Safe version checks all parameters, then calls real handler.
 
-Read handler pulls out the arguments, does any mandatory checking
+Pwrite handler pulls out the arguments, does any mandatory checking
 then calls the repy posix library pwrite system call.  Then packs
 the result back up.
 
 """
 
 def lind_fs_pwrite(args):
-    size = args[1]
+
     fd = args[0]
+    size = args[1]
     offset = args[2]
 
     # slice buffer string to only send size n bytes
@@ -24,7 +25,7 @@ def lind_fs_pwrite(args):
         try:
             result = get_fs_call(args[-1],"send_syscall")(fd, buffer, 0)
         except SyscallError, e:
-            print "PWrite failed with", e
+            print "Pwrite failed with", e
             return ErrorResponseBuilder("fs_pwrite", e[1], e[2])
     else:
         try:
@@ -35,12 +36,24 @@ def lind_fs_pwrite(args):
 
 
 def lind_safe_fs_pwrite(args):
-    size = args[1]
+
+    """ Safely wrap the pwrite call.
+
+    See dispatcher.repy for details.
+
+    Check the handle, size, offset, and buffer for consistency;
+    then call the real pwrite dispatcher.
+
+    """
+    
     fd = args[0]
+    size = args[1]
     offset = args[2]
     buffer = args[3]
     
-    assert size == len(buffer), "write size does not match buffer size"
+    assert isinstance(size, int)
+    assert isinstance(offset, int)
+    assert size == len(buffer), "pwrite size does not match buffer size"
     check_valid_fd_handle(fd)
 
     lind_fs_pwrite(args)

--- a/seattlelib/fs_pwrite.repy
+++ b/seattlelib/fs_pwrite.repy
@@ -1,0 +1,47 @@
+"""
+
+Handlers for the pwrite system call.
+
+Called from dispatcher.repy
+
+Safe version checks all parameters, then calls real handler.
+
+Read handler pulls out the arguments, does any mandatory checking
+then calls the repy posix library pwrite system call.  Then packs
+the result back up.
+
+"""
+
+def lind_fs_pwrite(args):
+    size = args[1]
+    fd = args[0]
+    offset = args[2]
+
+    # slice buffer string to only send size n bytes
+    buffer = args[3][:size]
+    
+    if IS_SOCK_DESC(fd,args[-1]):
+        try:
+            result = get_fs_call(args[-1],"send_syscall")(fd, buffer, 0)
+        except SyscallError, e:
+            print "PWrite failed with", e
+            return ErrorResponseBuilder("fs_pwrite", e[1], e[2])
+    else:
+        try:
+            result = get_fs_call(args[-1],"pwrite_syscall")(fd, buffer, offset)
+        except SyscallError, e:
+            return ErrorResponseBuilder("fs_pwrite", e[1], e[2])
+    return SuccessResponseBuilder("fs_pwrite", result)
+
+
+def lind_safe_fs_pwrite(args):
+    size = args[1]
+    fd = args[0]
+    offset = args[2]
+    buffer = args[3]
+    
+    assert size == len(buffer), "write size does not match buffer size"
+    check_valid_fd_handle(fd)
+
+    lind_fs_pwrite(args)
+    return SuccessResponseBuilder("fs_pwrite", size)

--- a/seattlelib/fs_pwrite.repy
+++ b/seattlelib/fs_pwrite.repy
@@ -53,7 +53,7 @@ def lind_safe_fs_pwrite(args):
     
     assert isinstance(size, int)
     assert isinstance(offset, int)
-    #assert size == len(buffer), "pwrite size does not match buffer size"
+    assert size == len(buffer), "pwrite size does not match buffer size"
     check_valid_fd_handle(fd)
 
     lind_fs_pwrite(args)

--- a/seattlelib/fs_pwrite.repy
+++ b/seattlelib/fs_pwrite.repy
@@ -53,7 +53,7 @@ def lind_safe_fs_pwrite(args):
     
     assert isinstance(size, int)
     assert isinstance(offset, int)
-    assert size == len(buffer), "pwrite size does not match buffer size"
+    #assert size == len(buffer), "pwrite size does not match buffer size"
     check_valid_fd_handle(fd)
 
     lind_fs_pwrite(args)

--- a/seattlelib/fs_pwrite.repy
+++ b/seattlelib/fs_pwrite.repy
@@ -22,11 +22,8 @@ def lind_fs_pwrite(args):
     buffer = args[3][:size]
     
     if IS_SOCK_DESC(fd,args[-1]):
-        try:
-            result = get_fs_call(args[-1],"send_syscall")(fd, buffer, 0)
-        except SyscallError, e:
-            print "Pwrite failed with", e
-            return ErrorResponseBuilder("fs_pwrite", e[1], e[2])
+        return ErrorResponseBuilder("pwrite_syscall","ESPIPE","File descriptor is associated with a pipe or FIFO or socket.")
+        
     else:
         try:
             result = get_fs_call(args[-1],"pwrite_syscall")(fd, buffer, offset)

--- a/seattlelib/fs_pwrite.repy
+++ b/seattlelib/fs_pwrite.repy
@@ -21,14 +21,11 @@ def lind_fs_pwrite(args):
     # slice buffer string to only send size n bytes
     buffer = args[3][:size]
     
-    if IS_SOCK_DESC(fd,args[-1]):
-        return ErrorResponseBuilder("fs_pwrite","ESPIPE","File descriptor is associated with a pipe or FIFO or socket.")
+    try:
+        result = get_fs_call(args[-1],"pwrite_syscall")(fd, buffer, offset)
+    except SyscallError, e:
+        return ErrorResponseBuilder("fs_pwrite", e[1], e[2])
         
-    else:
-        try:
-            result = get_fs_call(args[-1],"pwrite_syscall")(fd, buffer, offset)
-        except SyscallError, e:
-            return ErrorResponseBuilder("fs_pwrite", e[1], e[2])
     return SuccessResponseBuilder("fs_pwrite", result)
 
 

--- a/seattlelib/fs_pwrite.repy
+++ b/seattlelib/fs_pwrite.repy
@@ -22,7 +22,7 @@ def lind_fs_pwrite(args):
     buffer = args[3][:size]
     
     if IS_SOCK_DESC(fd,args[-1]):
-        return ErrorResponseBuilder("pwrite_syscall","ESPIPE","File descriptor is associated with a pipe or FIFO or socket.")
+        return ErrorResponseBuilder("fs_pwrite","ESPIPE","File descriptor is associated with a pipe or FIFO or socket.")
         
     else:
         try:

--- a/seattlelib/lind_fs_calls.py
+++ b/seattlelib/lind_fs_calls.py
@@ -1519,7 +1519,7 @@ def get_fs_call(CONST_CAGEID, CLOSURE_SYSCALL_NAME):
       if IS_PIPE_DESC(fd,CONST_CAGEID):
         return _read_from_pipe(fd, count)
 
-      read_from_file("read_syscall", fd, count, 0, filedescriptortable)
+      return read_from_file("read_syscall", fd, count, 0, filedescriptortable)
 
     finally:
       # ... release the lock
@@ -1559,7 +1559,7 @@ def get_fs_call(CONST_CAGEID, CLOSURE_SYSCALL_NAME):
     # ... but always release it...
     try:
 
-      read_from_file("pread_syscall", fd, count, offset, filedescriptortable)
+      return read_from_file("pread_syscall", fd, count, offset, filedescriptortable)
 
     finally:
       # ... release the lock
@@ -1687,7 +1687,7 @@ def get_fs_call(CONST_CAGEID, CLOSURE_SYSCALL_NAME):
       if IS_PIPE_DESC(fd,CONST_CAGEID):
         return _write_to_pipe(fd, data)
 
-      write_to_file("write_syscall", fd, data, 0, filedescriptortable)
+      return write_to_file("write_syscall", fd, data, 0, filedescriptortable)
 
     finally:
       # ... release the lock
@@ -1730,7 +1730,7 @@ def get_fs_call(CONST_CAGEID, CLOSURE_SYSCALL_NAME):
     # ... but always release it...
     try:
 
-      write_to_file("pwrite_syscall", fd, data, offset, filedescriptortable)
+      return write_to_file("pwrite_syscall", fd, data, offset, filedescriptortable)
 
     finally:
       # ... release the lock

--- a/seattlelib/lind_fs_calls.py
+++ b/seattlelib/lind_fs_calls.py
@@ -1613,14 +1613,14 @@ def get_fs_call(CONST_CAGEID, CLOSURE_SYSCALL_NAME):
         position = filedescriptortable[fd]['position']        
       else: #pwrite
         position = offset
-      print "File_Pos: ",filedescriptortable[fd]['position']," Write_to:", position,"\n"
+      print "File_Pos: ",filedescriptortable[fd]['position']," Write_to:", position," Filesize:",filesystemmetadata['inodetable'][inode]['size'],"\n"
       # and the file size...
       filesize = filesystemmetadata['inodetable'][inode]['size']
 
       # if the position is past the end of the file, write '\0' bytes to fill
       # up the gap...
       blankbytecount = position - filesize
-      print "blankbytecount: ",blankbytecount,"\n"
+      print " Filesize:",filesize , "blankbytecount: ",blankbytecount,"\n"
       if blankbytecount > 0:
         print "blankbytecount: ",blankbytecount," ",'\0'*blankbytecount,"\n"
         # let's write the blank part at the end of the file...

--- a/seattlelib/lind_fs_calls.py
+++ b/seattlelib/lind_fs_calls.py
@@ -1618,11 +1618,12 @@ def get_fs_call(CONST_CAGEID, CLOSURE_SYSCALL_NAME):
       # if the position is past the end of the file, write '\0' bytes to fill
       # up the gap...
       blankbytecount = position - filesize
-
+      
       if blankbytecount > 0:
         # let's write the blank part at the end of the file...
-        filesystemmetadata['inodetable'][inode]['size'] = position
         fileobjecttable[inode].writeat('\0'*blankbytecount,filesize)
+        filesystemmetadata['inodetable'][inode]['size'] = position
+        persist_metadata(METADATAFILENAME)
         filesize = position
 
       # writeat never writes less than desired in Repy V2.

--- a/seattlelib/lind_fs_calls.py
+++ b/seattlelib/lind_fs_calls.py
@@ -1621,8 +1621,9 @@ def get_fs_call(CONST_CAGEID, CLOSURE_SYSCALL_NAME):
 
       if blankbytecount > 0:
         # let's write the blank part at the end of the file...
+        filesystemmetadata['inodetable'][inode]['size'] = position
         fileobjecttable[inode].writeat('\0'*blankbytecount,filesize)
-
+        filesize = position
 
       # writeat never writes less than desired in Repy V2.
       fileobjecttable[inode].writeat(data,position)
@@ -1639,7 +1640,7 @@ def get_fs_call(CONST_CAGEID, CLOSURE_SYSCALL_NAME):
       
       else: #pwrite
         # update the file size if we've extended it
-        if position + len(data) > filesize:
+        if (position + len(data)) > filesize:
           filesystemmetadata['inodetable'][inode]['size'] = position + len(data)
           persist_metadata(METADATAFILENAME)
 

--- a/seattlelib/lind_fs_calls.py
+++ b/seattlelib/lind_fs_calls.py
@@ -1559,7 +1559,9 @@ def get_fs_call(CONST_CAGEID, CLOSURE_SYSCALL_NAME):
 
     # ... but always release it...
     try:
-
+      if IS_PIPE_DESC(fd,CONST_CAGEID):
+        raise SyscallError("pread_syscall","ESPIPE","File descriptor is associated with a pipe or FIFO or socket.")
+      
       return read_from_file("pread_syscall", fd, count, offset, filedescriptortable)
 
     finally:
@@ -1734,7 +1736,9 @@ def get_fs_call(CONST_CAGEID, CLOSURE_SYSCALL_NAME):
 
     # ... but always release it...
     try:
-
+      if IS_PIPE_DESC(fd,CONST_CAGEID):
+        raise SyscallError("pwrite_syscall","ESPIPE","File descriptor is associated with a pipe or FIFO or socket.")
+        
       return write_to_file("pwrite_syscall", fd, data, offset, filedescriptortable)
 
     finally:

--- a/seattlelib/lind_fs_calls.py
+++ b/seattlelib/lind_fs_calls.py
@@ -1559,7 +1559,7 @@ def get_fs_call(CONST_CAGEID, CLOSURE_SYSCALL_NAME):
 
     # ... but always release it...
     try:
-      if IS_PIPE_DESC(fd,CONST_CAGEID):
+      if IS_PIPE_DESC(fd,CONST_CAGEID) or IS_SOCK_DESC(fd,CONST_CAGEID):
         raise SyscallError("pread_syscall","ESPIPE","File descriptor is associated with a pipe or FIFO or socket.")
       
       return read_from_file("pread_syscall", fd, count, offset, filedescriptortable)
@@ -1734,7 +1734,7 @@ def get_fs_call(CONST_CAGEID, CLOSURE_SYSCALL_NAME):
 
     # ... but always release it...
     try:
-      if IS_PIPE_DESC(fd,CONST_CAGEID):
+      if IS_PIPE_DESC(fd,CONST_CAGEID) or IS_SOCK_DESC(fd,CONST_CAGEID):
         raise SyscallError("pwrite_syscall","ESPIPE","File descriptor is associated with a pipe or FIFO or socket.")
         
       return write_to_file("pwrite_syscall", fd, data, offset, filedescriptortable)

--- a/seattlelib/lind_fs_calls.py
+++ b/seattlelib/lind_fs_calls.py
@@ -1592,7 +1592,7 @@ def get_fs_call(CONST_CAGEID, CLOSURE_SYSCALL_NAME):
   #helper funtion for read/pread
   def write_to_file(syscall_name, fd, data, offset, filedescriptortable):
     
-    print("write_to_file",syscall_name,data, offset,sep=' ',end='\n')
+    print "write_to_file ",syscall_name," ",data, " ",offset,"\n"
     try:
       # Acquire the metadata lock... but always release it
       filesystemmetadatalock.acquire(True)
@@ -1709,7 +1709,7 @@ def get_fs_call(CONST_CAGEID, CLOSURE_SYSCALL_NAME):
     """
       https://linux.die.net/man/2/pwrite
     """
-    print("Pwrite",data, offset,sep=' ',end='\n')
+    print "Pwrite ",data, " ",offset" \n"
     filedescriptortable = masterfiledescriptortable[CONST_CAGEID]
 
     # check the fd

--- a/seattlelib/lind_fs_calls.py
+++ b/seattlelib/lind_fs_calls.py
@@ -1595,7 +1595,6 @@ def get_fs_call(CONST_CAGEID, CLOSURE_SYSCALL_NAME):
   #helper funtion for read/pread
   def write_to_file(syscall_name, fd, data, offset, filedescriptortable):
     
-    print "write_to_file | Origin:",syscall_name," | Offset:",offset," | Data:",data,"\n"
     try:
       # Acquire the metadata lock... but always release it
       filesystemmetadatalock.acquire(True)
@@ -1616,16 +1615,15 @@ def get_fs_call(CONST_CAGEID, CLOSURE_SYSCALL_NAME):
         position = filedescriptortable[fd]['position']        
       else: #pwrite
         position = offset
-      print "File_Pos: ",filedescriptortable[fd]['position']," | Write_to:", position," | Filesize:",filesystemmetadata['inodetable'][inode]['size'],"\n"
+      
       # and the file size...
       filesize = filesystemmetadata['inodetable'][inode]['size']
 
       # if the position is past the end of the file, write '\0' bytes to fill
       # up the gap...
       blankbytecount = position - filesize
-      print " Filesize:",filesize , " | Blankbytecount: ",blankbytecount,"\n"
+      
       if blankbytecount > 0:
-        print "blankbytecount: ",blankbytecount," ",'\0'*blankbytecount,"\n"
         # let's write the blank part at the end of the file...
         fileobjecttable[inode].writeat('\0'*blankbytecount,filesize)
         filesystemmetadata['inodetable'][inode]['size'] = position

--- a/seattlelib/lind_fs_calls.py
+++ b/seattlelib/lind_fs_calls.py
@@ -1591,6 +1591,8 @@ def get_fs_call(CONST_CAGEID, CLOSURE_SYSCALL_NAME):
   
   #helper funtion for read/pread
   def write_to_file(syscall_name, fd, data, offset, filedescriptortable):
+    
+    print("write_to_file",syscall_name,data, offset,sep=' ',end='\n')
     try:
       # Acquire the metadata lock... but always release it
       filesystemmetadatalock.acquire(True)
@@ -1660,7 +1662,7 @@ def get_fs_call(CONST_CAGEID, CLOSURE_SYSCALL_NAME):
     """
       http://linux.die.net/man/2/write
     """
-
+    
     filedescriptortable = masterfiledescriptortable[CONST_CAGEID]
 
     # check the fd
@@ -1707,7 +1709,7 @@ def get_fs_call(CONST_CAGEID, CLOSURE_SYSCALL_NAME):
     """
       https://linux.die.net/man/2/pwrite
     """
-
+    print("Pwrite",data, offset,sep=' ',end='\n')
     filedescriptortable = masterfiledescriptortable[CONST_CAGEID]
 
     # check the fd

--- a/seattlelib/lind_fs_calls.py
+++ b/seattlelib/lind_fs_calls.py
@@ -1613,15 +1613,16 @@ def get_fs_call(CONST_CAGEID, CLOSURE_SYSCALL_NAME):
         position = filedescriptortable[fd]['position']        
       else: #pwrite
         position = offset
-
+      print "File_Pos: ",filedescriptortable[fd]['position']," Write_to:", position,"\n"
       # and the file size...
       filesize = filesystemmetadata['inodetable'][inode]['size']
 
       # if the position is past the end of the file, write '\0' bytes to fill
       # up the gap...
       blankbytecount = position - filesize
+      print "blankbytecount: ",blankbytecount,"\n"
       if blankbytecount > 0:
-        print "blankbytecount ",blankbytecount," ",'\0'*blankbytecount,"\n"
+        print "blankbytecount: ",blankbytecount," ",'\0'*blankbytecount,"\n"
         # let's write the blank part at the end of the file...
         fileobjecttable[inode].writeat('\0'*blankbytecount,filesize)
         filesystemmetadata['inodetable'][inode]['size'] = position
@@ -1709,7 +1710,7 @@ def get_fs_call(CONST_CAGEID, CLOSURE_SYSCALL_NAME):
     """
       https://linux.die.net/man/2/pwrite
     """
-    print "Pwrite ",data," ",offset,"\n"
+    
     filedescriptortable = masterfiledescriptortable[CONST_CAGEID]
 
     # check the fd

--- a/seattlelib/lind_fs_calls.py
+++ b/seattlelib/lind_fs_calls.py
@@ -1592,7 +1592,7 @@ def get_fs_call(CONST_CAGEID, CLOSURE_SYSCALL_NAME):
   #helper funtion for read/pread
   def write_to_file(syscall_name, fd, data, offset, filedescriptortable):
     
-    print "write_to_file ",syscall_name," ",data, " ",offset,"\n"
+    print "write_to_file | Origin:",syscall_name," | Offset:",offset," | Data:",data,"\n"
     try:
       # Acquire the metadata lock... but always release it
       filesystemmetadatalock.acquire(True)
@@ -1613,14 +1613,14 @@ def get_fs_call(CONST_CAGEID, CLOSURE_SYSCALL_NAME):
         position = filedescriptortable[fd]['position']        
       else: #pwrite
         position = offset
-      print "File_Pos: ",filedescriptortable[fd]['position']," Write_to:", position," Filesize:",filesystemmetadata['inodetable'][inode]['size'],"\n"
+      print "File_Pos: ",filedescriptortable[fd]['position']," | Write_to:", position," | Filesize:",filesystemmetadata['inodetable'][inode]['size'],"\n"
       # and the file size...
       filesize = filesystemmetadata['inodetable'][inode]['size']
 
       # if the position is past the end of the file, write '\0' bytes to fill
       # up the gap...
       blankbytecount = position - filesize
-      print " Filesize:",filesize , "blankbytecount: ",blankbytecount,"\n"
+      print " Filesize:",filesize , " | Blankbytecount: ",blankbytecount,"\n"
       if blankbytecount > 0:
         print "blankbytecount: ",blankbytecount," ",'\0'*blankbytecount,"\n"
         # let's write the blank part at the end of the file...

--- a/seattlelib/lind_fs_calls.py
+++ b/seattlelib/lind_fs_calls.py
@@ -1256,8 +1256,9 @@ def get_fs_call(CONST_CAGEID, CLOSURE_SYSCALL_NAME):
           # if it exists, close the existing file object so I can remove it...
           if inode in fileobjecttable:
             fileobjecttable[inode].close()
-            # reset the size to 0
-            filesystemmetadata['inodetable'][inode]['size'] = 0
+            
+          # reset the size to 0
+          filesystemmetadata['inodetable'][inode]['size'] = 0
 
           # remove the file...
           removefile(FILEDATAPREFIX+str(inode))
@@ -1626,7 +1627,6 @@ def get_fs_call(CONST_CAGEID, CLOSURE_SYSCALL_NAME):
         # let's write the blank part at the end of the file...
         fileobjecttable[inode].writeat('\0'*blankbytecount,filesize)
         filesystemmetadata['inodetable'][inode]['size'] = position
-        persist_metadata(METADATAFILENAME)
         filesize = position
 
       # writeat never writes less than desired in Repy V2.

--- a/seattlelib/lind_fs_calls.py
+++ b/seattlelib/lind_fs_calls.py
@@ -1620,8 +1620,8 @@ def get_fs_call(CONST_CAGEID, CLOSURE_SYSCALL_NAME):
       # if the position is past the end of the file, write '\0' bytes to fill
       # up the gap...
       blankbytecount = position - filesize
-      
       if blankbytecount > 0:
+        print "blankbytecount ",blankbytecount," ",'\0'*blankbytecount,"\n"
         # let's write the blank part at the end of the file...
         fileobjecttable[inode].writeat('\0'*blankbytecount,filesize)
         filesystemmetadata['inodetable'][inode]['size'] = position

--- a/seattlelib/lind_fs_calls.py
+++ b/seattlelib/lind_fs_calls.py
@@ -1709,7 +1709,7 @@ def get_fs_call(CONST_CAGEID, CLOSURE_SYSCALL_NAME):
     """
       https://linux.die.net/man/2/pwrite
     """
-    print "Pwrite ",data, " ",offset" \n"
+    print "Pwrite ",data," ",offset,"\n"
     filedescriptortable = masterfiledescriptortable[CONST_CAGEID]
 
     # check the fd

--- a/seattlelib/lind_server.mix
+++ b/seattlelib/lind_server.mix
@@ -111,6 +111,8 @@ include fs_open.repy
 
 include fs_write.repy
 
+include fs_pwrite.repy
+
 include fs_fstatfs.repy
 
 include fs_statfs.repy
@@ -120,6 +122,8 @@ include comp.repy
 include fs_access.repy
 
 include fs_read.repy
+
+include fs_pread.repy
 
 include fs_fstat.repy
 


### PR DESCRIPTION
Added syscall implementations for pread and pwrite. Fixed a bug preventing the reset of the size of non-active inodes when using O_TRUNC option open syscall.